### PR TITLE
change vertex output to SV_POSITION and fragment to SV_TARGET where applicable

### DIFF
--- a/UnitySDK/Assets/TiltBrush/Assets/Brushes/Basic/CelVinyl/CelVinyl.shader
+++ b/UnitySDK/Assets/TiltBrush/Assets/Brushes/Basic/CelVinyl/CelVinyl.shader
@@ -47,7 +47,7 @@ Shader "Brush/Special/CelVinyl" {
         };
 
         struct v2f {
-            float4 vertex : POSITION;
+            float4 vertex : SV_POSITION;
             float2 texcoord : TEXCOORD0;
             float4 color : COLOR;
             UNITY_FOG_COORDS(1)
@@ -65,7 +65,7 @@ Shader "Brush/Special/CelVinyl" {
           return o;
         }
 
-        fixed4 frag (v2f i) : COLOR
+        fixed4 frag (v2f i) : SV_Target
         {
           fixed4 tex = tex2D(_MainTex, i.texcoord) * i.color;
           UNITY_APPLY_FOG(i.fogCoord, tex);

--- a/UnitySDK/Assets/TiltBrush/Assets/Brushes/Basic/ChromaticWave/ChromaticWave.shader
+++ b/UnitySDK/Assets/TiltBrush/Assets/Brushes/Basic/ChromaticWave/ChromaticWave.shader
@@ -49,7 +49,7 @@ Category {
       };
 
       struct v2f {
-        float4 vertex : POSITION;
+        float4 vertex : SV_POSITION;
         float4 color : COLOR;
         float2 texcoord : TEXCOORD0;
         float4 unbloomedColor : TEXCOORD1;
@@ -67,7 +67,7 @@ Category {
       }
 
       // Input color is srgb
-      fixed4 frag (v2f i) : COLOR
+      fixed4 frag (v2f i) : SV_Target
       {
         // Envelope
         float envelope = sin(i.texcoord.x * 3.14159);

--- a/UnitySDK/Assets/TiltBrush/Assets/Brushes/Basic/DoubleTaperedMarker/DoubleTaperedMarker.shader
+++ b/UnitySDK/Assets/TiltBrush/Assets/Brushes/Basic/DoubleTaperedMarker/DoubleTaperedMarker.shader
@@ -44,7 +44,7 @@ Category {
       };
 
       struct v2f {
-        float4 vertex : POSITION;
+        float4 vertex : SV_POSITION;
         fixed4 color : COLOR;
         float2 texcoord : TEXCOORD0;
         UNITY_FOG_COORDS(1)
@@ -68,7 +68,7 @@ Category {
         return o;
       }
 
-      fixed4 frag (v2f i) : COLOR
+      fixed4 frag (v2f i) : SV_Target
       {
 
         UNITY_APPLY_FOG(i.fogCoord, i.color.rgb);

--- a/UnitySDK/Assets/TiltBrush/Assets/Brushes/Basic/Electricity/Electricity.shader
+++ b/UnitySDK/Assets/TiltBrush/Assets/Brushes/Basic/Electricity/Electricity.shader
@@ -38,7 +38,7 @@ CGINCLUDE
   half _EmissionGain;
 
   struct v2f {
-    float4 vertex : POSITION;
+    float4 vertex : SV_POSITION;
     fixed4 color : COLOR;
     float2 texcoord : TEXCOORD0;
   };
@@ -112,7 +112,7 @@ CGINCLUDE
   }
 
   // Input color is srgb
-  fixed4 frag (v2f i) : COLOR
+  fixed4 frag (v2f i) : SV_Target
   {
     // interior procedural line
     float procedural = ( abs(i.texcoord.y - 0.5) < .1 ) ? 2 : 0;

--- a/UnitySDK/Assets/TiltBrush/Assets/Brushes/Basic/Highlighter/AdditiveCutout.shader
+++ b/UnitySDK/Assets/TiltBrush/Assets/Brushes/Basic/Highlighter/AdditiveCutout.shader
@@ -46,7 +46,7 @@ Category {
       };
 
       struct v2f {
-        float4 vertex : POSITION;
+        float4 vertex : SV_POSITION;
         fixed4 color : COLOR;
         float2 texcoord : TEXCOORD0;
       };
@@ -63,7 +63,7 @@ Category {
         return o;
       }
 
-      fixed4 frag (v2f i) : COLOR
+      fixed4 frag (v2f i) : SV_Target
       {
          half4 c = tex2D(_MainTex, i.texcoord );
 

--- a/UnitySDK/Assets/TiltBrush/Assets/Brushes/Basic/Plasma/Plasma.shader
+++ b/UnitySDK/Assets/TiltBrush/Assets/Brushes/Basic/Plasma/Plasma.shader
@@ -59,7 +59,7 @@ Category {
       };
 
       struct v2f {
-        float4 vertex : POSITION;
+        float4 vertex : SV_POSITION;
         fixed4 color : COLOR;
         float2 texcoord : TEXCOORD0;
         float3 worldPos : TEXCOORD1;
@@ -90,7 +90,7 @@ Category {
         return abs(noise.x + noise.y) * 0.5;
       }
 
-      fixed4 frag (v2f i) : COLOR
+      fixed4 frag (v2f i) : SV_Target
       {
         // Workaround for b/30500118, caused by b/30504121
         i.color.a = saturate(i.color.a);

--- a/UnitySDK/Assets/TiltBrush/Assets/Brushes/Basic/Rainbow/Rainbow.shader
+++ b/UnitySDK/Assets/TiltBrush/Assets/Brushes/Basic/Rainbow/Rainbow.shader
@@ -48,7 +48,7 @@ Category {
       };
 
       struct v2f {
-        float4 vertex : POSITION;
+        float4 vertex : SV_POSITION;
         fixed4 color : COLOR;
         float2 texcoord : TEXCOORD0;
       };
@@ -153,7 +153,7 @@ Category {
       }
 
       // Input color is srgb
-      fixed4 frag (v2f i) : COLOR
+      fixed4 frag (v2f i) : SV_Target
       {
         i.color.a = 1; //ignore incoming vert alpha
 #ifdef AUDIO_REACTIVE

--- a/UnitySDK/Assets/TiltBrush/Assets/Brushes/Basic/SoftHighlighter/SoftHighlighter.shader
+++ b/UnitySDK/Assets/TiltBrush/Assets/Brushes/Basic/SoftHighlighter/SoftHighlighter.shader
@@ -45,7 +45,7 @@ Category {
       };
 
       struct v2f {
-        float4 vertex : POSITION;
+        float4 vertex : SV_POSITION;
         fixed4 color : COLOR;
         float2 texcoord : TEXCOORD0;
       };
@@ -72,7 +72,7 @@ Category {
 
       }
 
-      fixed4 frag (v2f i) : COLOR
+      fixed4 frag (v2f i) : SV_Target
       {
          half4 c = tex2D(_MainTex, i.texcoord );
         return i.color * c;

--- a/UnitySDK/Assets/TiltBrush/Assets/Brushes/Basic/Streamers/Streamers.shader
+++ b/UnitySDK/Assets/TiltBrush/Assets/Brushes/Basic/Streamers/Streamers.shader
@@ -53,7 +53,7 @@ Category {
       };
 
       struct v2f {
-        float4 vertex : POSITION;
+        float4 vertex : SV_POSITION;
         fixed4 color : COLOR;
         float2 texcoord : TEXCOORD0;
         float4 worldPos : TEXCOORD1;
@@ -84,7 +84,7 @@ Category {
       }
 
       // Input color is srgb
-      fixed4 frag (v2f i) : COLOR
+      fixed4 frag (v2f i) : SV_Target
       {
         // Create parametric flowing UV's
         half2 uvs = i.texcoord;

--- a/UnitySDK/Assets/TiltBrush/Assets/Brushes/Basic/VelvetInk/VelvetInk.shader
+++ b/UnitySDK/Assets/TiltBrush/Assets/Brushes/Basic/VelvetInk/VelvetInk.shader
@@ -45,7 +45,7 @@ Category {
       };
 
       struct v2f {
-        float4 vertex : POSITION;
+        float4 vertex : SV_POSITION;
         fixed4 color : COLOR;
         float2 texcoord : TEXCOORD0;
       };
@@ -71,7 +71,7 @@ Category {
         return o;
       }
 
-      fixed4 frag (v2f i) : COLOR
+      fixed4 frag (v2f i) : SV_Target
       {
          half4 c = tex2D(_MainTex, i.texcoord );
         return i.color * c;

--- a/UnitySDK/Assets/TiltBrush/Assets/Brushes/Basic/Waveform/Waveform.shader
+++ b/UnitySDK/Assets/TiltBrush/Assets/Brushes/Basic/Waveform/Waveform.shader
@@ -51,7 +51,7 @@ Category {
       };
 
       struct v2f {
-        float4 vertex : POSITION;
+        float4 vertex : SV_POSITION;
         float4 color : COLOR;
         float2 texcoord : TEXCOORD0;
         float4 unbloomedColor : TEXCOORD1;
@@ -70,7 +70,7 @@ Category {
       }
 
       // Input colors are srgb
-      fixed4 frag (v2f i) : COLOR
+      fixed4 frag (v2f i) : SV_Target
       {
         // Envelope
         float envelope = sin(i.texcoord.x * 3.14159);

--- a/UnitySDK/Assets/TiltBrush/Assets/Brushes/Shared/Shaders/Unlit.shader
+++ b/UnitySDK/Assets/TiltBrush/Assets/Brushes/Shared/Shaders/Unlit.shader
@@ -45,7 +45,7 @@ SubShader {
         };
 
         struct v2f {
-            float4 vertex : POSITION;
+            float4 vertex : SV_POSITION;
             float2 texcoord : TEXCOORD0;
             float4 color : COLOR;
             UNITY_FOG_COORDS(1)
@@ -63,7 +63,7 @@ SubShader {
             return o;
         }
 
-        fixed4 frag (v2f i) : COLOR
+        fixed4 frag (v2f i) : SV_Target
         {
             fixed4 c;
             UNITY_APPLY_FOG(i.fogCoord, i.color);


### PR DESCRIPTION
Some fragment shaders are using target symantics which may be problematic on some platforms, so change vertex output to SV_POSITION and fragment to SV_TARGET
